### PR TITLE
Add `Argument.IsNullOrWhiteSpace(string, string)`.

### DIFF
--- a/Argument.Tests/ArgumentTests.cs
+++ b/Argument.Tests/ArgumentTests.cs
@@ -37,6 +37,14 @@ public class ArgumentTests {
     }
 
     [Theory]
+    [MemberData(nameof(WhiteSpaceVariants))]
+    public void NotNullOrWhiteSpaceVariant_ThrowsArgumentException_WithCorrectParamName_WhenValueIsWhiteSpace(Expression<Action<string>> validateExpression) {
+        var validate = validateExpression.Compile();
+        var exception = Assert.Throws<ArgumentException>(() => validate("x"));
+        Assert.Equal("x", exception.ParamName);
+    }
+
+    [Theory]
     [MemberData(nameof(IncorrectTypeVariants))]
     public void CastVariant_ThrowsArgumentException_WithCorrectParamName_WhenValueHasIncorrectType(Expression<Action<string>> validateExpression) {
         var validate = validateExpression.Compile();
@@ -75,6 +83,7 @@ public class ArgumentTests {
             yield return SimpleDataRow(name => Argument.NotNullOrEmpty(name, null!));
             yield return SimpleDataRow(name => Argument.NotNullOrEmpty(name, (object[]?)null!));
             yield return SimpleDataRow(name => Argument.NotNullOrEmpty(name, (List<object>?)null!));
+            yield return SimpleDataRow(name => Argument.NotNullOrWhiteSpace(name, null!));
             yield return SimpleDataRow(name => Argument.NotNullAndCast<object>(name, null!));
         }
     }
@@ -87,6 +96,13 @@ public class ArgumentTests {
             yield return SimpleDataRow(name => Argument.NotNullOrEmpty(name, new List<int>()));
             yield return SimpleDataRow(name => Argument.NotNullOrEmpty(name, (IReadOnlyCollection<int>)new List<int>()));
             yield return SimpleDataRow(name => Argument.NotNullOrEmpty(name, ImmutableList.Create<int>()));
+            yield return SimpleDataRow(name => Argument.NotNullOrWhiteSpace(name, ""));
+        }
+    }
+
+    public static IEnumerable<object[]> WhiteSpaceVariants {
+        get {
+            yield return SimpleDataRow(name => Argument.NotNullOrWhiteSpace(name, "\t"));
         }
     }
 
@@ -120,6 +136,7 @@ public class ArgumentTests {
             yield return SuccessDataRow("abc",         value => Argument.NotNullOrEmpty("x", value));
             yield return SuccessDataRow(new object[1], value => Argument.NotNullOrEmpty("x", value));
             yield return SuccessDataRow(new List<object> { new object() }, value => Argument.NotNullOrEmpty("x", value));
+            yield return SuccessDataRow(" abc ",       value => Argument.NotNullOrWhiteSpace("x", value));
 
             yield return SuccessDataRow("abc",         value => Argument.Cast<string>("x", value));
             yield return SuccessDataRow("abc",         value => Argument.NotNullAndCast<string>("x", value));

--- a/Argument.Tests/CodeAnalysisTests.cs
+++ b/Argument.Tests/CodeAnalysisTests.cs
@@ -7,7 +7,7 @@ public class CodeAnalysisTests {
         return argument.Length;
     }
 
-    public int CA1062ArgumentCheck_NotRequired_NotNullOrEmpty_String(string argument) {
+    public int CA1062_ArgumentCheck_NotRequired_NotNullOrEmpty_String(string argument) {
         Argument.NotNullOrEmpty(nameof(argument), argument);
         return argument.Length;
     }
@@ -20,6 +20,11 @@ public class CodeAnalysisTests {
     public int CA1062_ArgumentCheck_NotRequired_NotNullOrEmpty_List(IReadOnlyList<int> argument) {
         Argument.NotNullOrEmpty(nameof(argument), argument);
         return argument.Count;
+    }
+
+    public int CA1062_ArgumentCheck_NotRequired_NotNullOrWhiteSpace_String(string argument) {
+        Argument.NotNullOrWhiteSpace(nameof(argument), argument);
+        return argument.Length;
     }
 
     public int CA1062_ArgumentCheck_NotRequired_NotNullAndCast(string argument) {

--- a/Argument.Tests/NullableFlowTests.cs
+++ b/Argument.Tests/NullableFlowTests.cs
@@ -22,6 +22,11 @@ public class NullableFlowTests {
         return argument.Count;
     }
 
+    public int CS8602_ValueIsNotNullable_After_NotNullOrWhiteSpace_String(string? argument) {
+        Argument.NotNullOrWhiteSpace(nameof(argument), argument!);
+        return argument.Length;
+    }
+
     public int CS8602_ValueIsNotNullable_After_NotNullAndCast(string? argument) {
         Argument.NotNullAndCast<string>(nameof(argument), argument!);
         return argument.Length;

--- a/Argument/Argument.cs
+++ b/Argument/Argument.cs
@@ -140,6 +140,37 @@ public static class Argument {
         return value;
     }
 
+    /// <summary>
+    /// Verifies that a given argument value is not <c>null</c>, empty, or consists only of white-space characters and returns the value provided.
+    /// </summary>
+    /// <param name="name">Argument name.</param>
+    /// <param name="value">Argument value.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="value"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> is empty.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value"/> consists only of white-space characters.</exception>
+    /// <returns><paramref name="value"/> if it is not <c>null</c>, empty, or consists only of white-space characters.</returns>
+    [NotNull, AssertionMethod]
+    [ContractAnnotation("value:null => halt;value:notnull => notnull")]
+    [ContractArgumentValidator]
+    public static string NotNullOrWhiteSpace(
+        [NotNull, InvokerParameterName] string name,
+        [NotNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), ValidatedNotNull, CodeAnalysis.NotNull] string value
+    ) {
+        Argument.NotNullOrEmpty(name, value);
+        bool containsOnlyWhiteSpace = true;
+        for(int i = 0; i < value.Length; i++) {
+            if (!char.IsWhiteSpace(value[i])) {
+                containsOnlyWhiteSpace = false;
+                break;
+            }
+        }
+        if (containsOnlyWhiteSpace)
+            throw new ArgumentException("Value cannot consist only of white-space characters.", name);
+        Contract.EndContractBlock();
+
+        return value;
+    }
+
     private const string PotentialDoubleEnumeration = "Using NotNullOrEmpty with plain IEnumerable may cause double enumeration. Please use a collection instead.";
 
     /// <summary>

--- a/Argument/Argument.cs
+++ b/Argument/Argument.cs
@@ -157,8 +157,8 @@ public static class Argument {
         [NotNull, AssertionCondition(AssertionConditionType.IS_NOT_NULL), ValidatedNotNull, CodeAnalysis.NotNull] string value
     ) {
         Argument.NotNullOrEmpty(name, value);
-        bool containsOnlyWhiteSpace = true;
-        for(int i = 0; i < value.Length; i++) {
+        var containsOnlyWhiteSpace = true;
+        for (var i = 0; i < value.Length; i++) {
             if (!char.IsWhiteSpace(value[i])) {
                 containsOnlyWhiteSpace = false;
                 break;


### PR DESCRIPTION
This feature adds validation for strings to ensure that the string does not contain only white space.

The logic for testing for white space is based on the source code for strings (lines 801-803):
https://referencesource.microsoft.com/#mscorlib/system/string.cs